### PR TITLE
Group deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ lambda:
     SLACK_VERIFICATION_TOKEN: "asdf1234asdf"
     SLACK_CHANNEL: "ecs-notifications"
     INCLUDED_CLUSTERS: "production,staging"
+    SERVICE_GROUPS_TABLE: "ecs-slack-ServiceGroups"
 ```
 
 5. Install the app on aws
@@ -37,3 +38,17 @@ sls deploy
 Create a slash command `/ecs-deploy` in the Slack app. Set the `Request URL` to the API Gateway created by serverless. 
   - Go to API Gateway and select dev-ecs-slack
   - Under stages get the `Invoke URL` from POST method under /deploy
+
+7. Configure service groups (optional)
+Create items in dynamodb table `ecs-slack-ServiceGroups` to configure service groups. Example:
+```json
+{
+  "group": "myapp",
+  "services": [
+    "myapp",
+    "myapp-worker-1",
+    "myapp-worker-2"
+  ]
+}
+```
+Then to trigger a deployment in slack run: `/ecs-deploy <cluster_name> myapp <reference> -g`

--- a/README.md
+++ b/README.md
@@ -2,10 +2,9 @@
 Based on the AWS example for handling ECS events https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs_cwet_handling.html
 
 # Installation
-1. Requires changes from https://github.com/serverless/serverless/pull/4694 which
-will be released with version 1.27. Until then just install from master.
+1. Requires changes from https://github.com/serverless/serverless/pull/4694. Install serverless 1.27.0 or higher.
 ```bash
-npm install -g serverless/serverless#master
+npm install -g serverless@^1.27.0
 ```
 
 2. Install python requirements serverless plugin in the app directory.

--- a/serverless.yml
+++ b/serverless.yml
@@ -6,6 +6,7 @@ custom:
   instance_state_table: ${self:service}-ECSCtrInstanceState
   task_state_table: ${self:service}-ECSTaskState
   task_digest_table: ${self:service}-ECSTaskDigest
+  service_groups_table: ${self:service}-ServiceGroups
   capacities:
     - table: ECSTaskDigest  # Autoscale Digest Table read/write
       read:
@@ -38,6 +39,7 @@ provider:
         - "arn:aws:dynamodb:*:*:table/${self:custom.instance_state_table}"
         - "arn:aws:dynamodb:*:*:table/${self:custom.task_state_table}"
         - "arn:aws:dynamodb:*:*:table/${self:custom.task_digest_table}"
+        - "arn:aws:dynamodb:*:*:table/${self:custom.service_groups_table}"
     - Effect: "Allow"
       Action:
         - "ecs:Describe*"
@@ -142,3 +144,17 @@ resources:
         TimeToLiveSpecification:
           AttributeName: TTL
           Enabled: True
+
+    ServiceGroups:
+      Type: AWS::DynamoDB::Table
+      Properties:
+        TableName: ${self:custom.service_groups_table}
+        AttributeDefinitions:
+          - AttributeName: group
+            AttributeType: S
+        KeySchema:
+          - AttributeName: group
+            KeyType: HASH
+        ProvisionedThroughput:
+          ReadCapacityUnits: 5
+          WriteCapacityUnits: 5


### PR DESCRIPTION
Adds support for group deployments in slack. The groups are configured in dynamodb table `ecs-slack-ServiceGroups`.

Each group is a separate item. Example:
```json
{
  "group": "myapp",
  "services": [
    "myapp",
    "myapp-worker-1",
    "myapp-worker-2"
  ]
}
```